### PR TITLE
Limitante para fechas en las ordenes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ yarn-error.log*
 
 # local env files
 .env
+
+# BD
+*.db
+*.sql

--- a/src/pages/orders/index.jsx
+++ b/src/pages/orders/index.jsx
@@ -50,7 +50,9 @@ const orderSchema = yup.object().shape({
   product_id: yup.string().required("Requerido"),
   provider_id: yup.string().required("Requerido"),
   quantity: yup.number().required("Requerido").min(1, "Debe ser al menos 1"),
-  expected_date: yup.date().nullable(),
+  
+  expected_date: yup.date().nullable()
+    .min(new Date(new Date().setHours(0,0,0,0)), "La fecha no puede ser anterior a hoy"),
   notes: yup.string().nullable(),
 });
 


### PR DESCRIPTION
Se agregaron reglas de validación al campo de fecha esperada para prevenir registros con fechas pasadas, garantizando que solo se acepten fechas a partir del día en curso. También se tipó el campo de notas como opcional.

Se añadió una restricción .min() para evitar que el usuario seleccione una fecha pasada. Ademas new Date().setHours(0,0,0,0) establece el límite al comienzo del día actual, permitiendo seleccionar el día de hoy pero bloqueando ayer o fechas anteriores.